### PR TITLE
implements #313

### DIFF
--- a/controllers/show.php
+++ b/controllers/show.php
@@ -124,6 +124,33 @@ class ShowController extends StudipController
     {
     }
 
+    public function updatevorlage_action($vorlage_id)
+    {
+        if (!$GLOBALS['perm']->have_studip_perm('dozent', $vorlage_id)) {
+            throw new Exception('Access denied');
+        }
+        
+        $seminar = Seminar::getInstance($vorlage_id);
+
+        if(Request::submitted('updatevorlage')) {
+            $sem_name        = strip_tags(Request::get('name'));
+            $sem_description = strip_tags(Request::get('description'));
+            
+            $seminar->name = $sem_name;
+            $seminar->description = $sem_description;
+
+            $seminar->store();
+
+            PageLayout::postMessage(MessageBox::success(sprintf(_('Vorlage "%s" wurde angelegt.'), $sem_name)));
+
+            $this->response->add_header('X-Dialog-Close', '1');
+            $this->render_nothing();
+        } else {
+            $this->template_name = $seminar->name;
+            $this->template_description = $seminar->description;
+        }
+    }
+
     public function newvorlage_action()
     {
         $sem_type_id      = Config::get()->SEM_CLASS_PORTFOLIO_VORLAGE;

--- a/controllers/showsupervisor.php
+++ b/controllers/showsupervisor.php
@@ -159,6 +159,33 @@ class ShowsupervisorController extends StudipController
         $this->redirect('showsupervisor?cid=' . $groupid);
     }
 
+    public function updatevorlage_action($vorlage_id)
+    {
+        if (!$GLOBALS['perm']->have_studip_perm('dozent', $vorlage_id)) {
+            throw new Exception('Access denied');
+        }
+        
+        $seminar = Seminar::getInstance($vorlage_id);
+
+        if(Request::submitted('updatevorlage')) {
+            $sem_name        = strip_tags(Request::get('name'));
+            $sem_description = strip_tags(Request::get('description'));
+            
+            $seminar->name = $sem_name;
+            $seminar->description = $sem_description;
+
+            $seminar->store();
+
+            PageLayout::postMessage(MessageBox::success(sprintf(_('Vorlage "%s" wurde angelegt.'), $sem_name)));
+
+            $this->response->add_header('X-Dialog-Close', '1');
+            $this->render_nothing();
+        } else {
+            $this->template_name = $seminar->name;
+            $this->template_description = $seminar->description;
+        }
+    }
+
     public function url_for($to = '')
     {
         $args = func_get_args();

--- a/views/show/index.php
+++ b/views/show/index.php
@@ -52,6 +52,12 @@
                         <?php
                             $actionMenu = ActionMenu::get();
                             $actionMenu->addLink(
+                                PluginEngine::getLink($this->plugin, [], 'show/updatevorlage/' . $portfolio->id),
+                                _('Portfolio-Titel und Beschreibung bearbeiten'),
+                                Icon::create('edit', 'clickable'),
+                                ['data-dialog' => 'size=auto;reload-on-close']
+                            );
+                            $actionMenu->addLink(
                                 URLHelper::getUrl('plugins.php/courseware/courseware', [
                                    'cid'         => $portfolio->id,
                                    'return_to'   => 'overview'

--- a/views/show/updatevorlage.php
+++ b/views/show/updatevorlage.php
@@ -1,0 +1,18 @@
+<form data-dialog="size=auto;reload-on-close"
+      action="<?= URLHelper::getLink("plugins.php/eportfolioplugin/show/updatevorlage/" . basename(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH))) ?>"
+      method="post" enctype="multipart/form-data" class="default"
+    <?= Request::isAjax() ? "data-dialog" : "" ?>>
+    
+    <label>
+        <?= _("Name") ?>
+        <input type="text" name="name" required="" class="size-l" value="<?echo $template_name?>">
+    </label>
+    <label>
+        <?= _("Beschreibung") ?>
+        <input type="text" name="description" required="" class="size-l" value="<?echo $template_description?>">
+    </label>
+
+    <div data-dialog-button>
+        <?= \Studip\Button::create(_("Speichern"), 'updatevorlage', ["data-dialog" => ""]) ?>
+    </div>
+</form>

--- a/views/showsupervisor/_templates.php
+++ b/views/showsupervisor/_templates.php
@@ -87,35 +87,52 @@
                 <? endif ?>
                 </td>
                 <td style="text-align: center;">
-                    <?php $groupHasTemplate = EportfolioGroupTemplates::checkIfGroupHasTemplate($id, $portfolio->id)?>
-                    <a href="<?= URLHelper::getLink('plugins.php/courseware/courseware', [
-                            'cid'       => $portfolio->id,
-                            'return_to' => Context::getId()
-                    ]); ?>">
-                        <?= Icon::create('edit', Icon::ROLE_CLICKABLE, ['title' => sprintf(_('Portfolio-Vorlage bearbeiten.'))]) ?>
-                    </a>
+                    <?php
+                        $actionMenu = ActionMenu::get();
+                        $actionMenu->addLink(
+                            PluginEngine::getLink($this->plugin, [], 'showsupervisor/updatevorlage/' . $portfolio->id),
+                            _('Portfolio-Titel und Beschreibung bearbeiten'),
+                            Icon::create('edit', 'clickable'),
+                            ['data-dialog' => 'size=auto;reload-on-close']
+                        );
+                        $actionMenu->addLink(
+                            URLHelper::getUrl('plugins.php/courseware/courseware', [
+                               'cid'         => $portfolio->id,
+                               'return_to'   => 'overview'
+                           ]),
+                            _('Portfolio-Vorlage bearbeiten'),
+                            Icon::create('edit', 'clickable')
+                        );
+                        if ($member && !$groupHasTemplate) {
+                            $actionMenu->addLink(
+                                PluginEngine::getLink($this->plugin, [], 'showsupervisor/createportfolio/' . $portfolio->id),
+                                _('Portfolio-Vorlage an Gruppenmitglieder verteilen.'),
+                                Icon::create('share', 'clickable'),
+                                ['data-confirm' => _('Vorlage an Teilnehmende verteilen')]
+                            );
+                        }
+                        /* favs not yet supported
+                        if ($member && $groupHasTemplate){
+                            if (EportfolioGroup::checkIfMarkedAsFav($id, $portfolio->id) == 0){
+                                $actionMenu->addLink(
+                                    PluginEngine::getLink($this->plugin, [], 'showsupervisor/addAsFav/' . $id . '/' . $portfolio->id),
+                                    _('Portfolio-Vorlage als Favorit markieren),
+                                    Icon::create('visibility-invisible', 'clickable')
 
-                    <? if ($member && !$groupHasTemplate): ?>
-                        <a data-confirm="<?= _('Vorlage an Teilnehmende verteilen') ?>"
-                           href="<?= $controller->url_for('showsupervisor/createportfolio/' . $portfolio->id) ?>">
-                            <?= Icon::create('share', Icon::ROLE_CLICKABLE, tooltip2(_('Portfolio-Vorlage an Gruppenmitglieder verteilen.')) + ['cursor' => 'pointer']) ?>
-                        </a>
-                    <? endif ?>
+                                );
+                            } else {
+                                $actionMenu->addLink(
+                                    PluginEngine::getLink($this->plugin, [], 'showsupervisor/deleteAsFav/' . $id . '/' . $portfolio->id),
+                                    _('Portfolio-Vorlage als Favorit markieren),
+                                    Icon::create('visibility-invisible', 'attention')
+
+                                );
+                            }
+                        }
+                         */
+                    ?>
+                    <?= $actionMenu->render() ?>
                 </td>
-                <!--
-                <td style="text-align: center;">
-                    <? if ($member && $groupHasTemplate): ?>
-                        <? if (EportfolioGroup::checkIfMarkedAsFav($id, $portfolio->id) == 0): ?>
-                            <a href="<?= $controller->url_for('showsupervisor/addAsFav/' . $id . '/' . $portfolio->id); ?>">
-                                <?= Icon::create('visibility-invisible', Icon::ROLE_CLICKABLE) ?>
-                            </a>
-                        <? else: ?>
-                            <a href="<?= $controller->url_for('showsupervisor/deleteAsFav/' . $id . '/' . $portfolio->id); ?>">
-                                <?= Icon::create('visibility-visible', Icon::ROLE_ATTENTION) ?>
-                            </a>
-                        <? endif ?>
-                    <? endif ?>
-                </td>-->
             </tr>
         <? endforeach; ?>
     </tbody>

--- a/views/showsupervisor/updatevorlage.php
+++ b/views/showsupervisor/updatevorlage.php
@@ -1,0 +1,18 @@
+<form data-dialog="size=auto;reload-on-close"
+      action="<?= URLHelper::getLink("plugins.php/eportfolioplugin/showsupervisor/updatevorlage/" . basename(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH))) ?>"
+      method="post" enctype="multipart/form-data" class="default"
+    <?= Request::isAjax() ? "data-dialog" : "" ?>>
+    
+    <label>
+        <?= _("Name") ?>
+        <input type="text" name="name" required="" class="size-l" value="<?echo $template_name?>">
+    </label>
+    <label>
+        <?= _("Beschreibung") ?>
+        <input type="text" name="description" required="" class="size-l" value="<?echo $template_description?>">
+    </label>
+
+    <div data-dialog-button>
+        <?= \Studip\Button::create(_("Speichern"), 'updatevorlage', ["data-dialog" => ""]) ?>
+    </div>
+</form>


### PR DESCRIPTION
Implementiert die Möglichkeit den Titel und die Beschreibung von Portfolios zu ändern(#313). Dazu wurde auf dem Profil ein weiterer Link dem Actionmenu hinzugefügt.
Dieser sorgt dafür, dass sich ein Dialog, der dem Dialog zum Erstellen einer Vorlage entspricht, öffnet, mit den vorher gesetzten Werten gefüllt wird und es dem Nutzer so ermöglicht diese zu ändern.
Auf der Veranstaltungsseite wurden die bisherigen Aktionen (Portfolio bearbeiten und Portfolio verteilen in einem Actionmenu gruppiert, sodass die Möglichkeit besteht so wie auf dem Profil das Bearbeiten des Titels und der Beschreibung zu Verfügung zu stellen.