### PR TITLE
fixes #323

### DIFF
--- a/models/EportfolioFreigabe.class.php
+++ b/models/EportfolioFreigabe.class.php
@@ -55,7 +55,8 @@ class EportfolioFreigabe extends SimpleORMap
      * @param string $seminar_id id of seminar(eportfolio)
      * @param int $chapter_id of courseware_chapter (Mooc\block)
      */
-    public static function userList($seminar_id, $chapter_id) {
+    public static function userList($seminar_id, $chapter_id)
+    {
         $accessList = EportfolioFreigabe::findBySQL('Seminar_id = :seminar_id AND block_id = :block_id',
             [':seminar_id' => $seminar_id, ':block_id' => $chapter_id]);
         

--- a/models/EportfolioFreigabe.class.php
+++ b/models/EportfolioFreigabe.class.php
@@ -47,6 +47,26 @@ class EportfolioFreigabe extends SimpleORMap
             return false;
         }
     }
+    
+    /**
+     * Given a Portfolio and a Block of said Portfolio
+     * return a string of all users with access to the Block
+     * 
+     * @param string $seminar_id id of seminar(eportfolio)
+     * @param int $chapter_id of courseware_chapter (Mooc\block)
+     */
+    public static function userList($seminar_id, $chapter_id) {
+        $accessList = EportfolioFreigabe::findBySQL('Seminar_id = :seminar_id AND block_id = :block_id',
+            [':seminar_id' => $seminar_id, ':block_id' => $chapter_id]);
+        
+        $users = array();
+        foreach ($accessList as $user) {
+            $users[] = User::find($user["user_id"])->getFullname();
+        }
+        usort($users, "strcmp");
+
+        return implode(", ", $users);
+    }
 
     /**
      * Give primary key of record as param to fetch

--- a/views/showsupervisor/memberdetail.php
+++ b/views/showsupervisor/memberdetail.php
@@ -120,7 +120,7 @@
             <div class="col-sm-8">
                 <div class="row" style="text-align: center;">
                     <div class="col-sm-2">
-                        <?php if ($statusKapitel = Eportfoliomodel::checkKapitelFreigabe($kapitel['id'])): ?>
+                        <?php if ($statusKapitel = Eportfoliomodel::checkKapitelFreigabe($kapitel['id']) && EportfolioFreigabe::hasAccess($GLOBALS['user']->id, $portfolio_id, $kapitel['id'])): ?>
                             <?php $new_freigabe = object_get_visit($portfolio_id, 'sem', 'last', false, $user_id) < EportfolioFreigabe::hasAccessSince($supervisorGroupId, $kapitel['id']); ?>
                             <?php if ($new_freigabe): ?>
                                 <?= Icon::create('accept+new', 'status-green'); ?>
@@ -149,15 +149,13 @@
                                     </a>
                                 <? endif; ?>
                             <? else: ?>
-                                Freigegeben aber kein Zugriff!
-                                <?= tooltipIcon("Nutzer hat dieses Kapitel freigegeben, Sie sind jedoch eventuell nicht in der Supervisionsgruppe und können deshalb nicht darauf zugreifen!"); ?>
+                                Nicht für die Berechtigtengruppe freigegeben
+                                <?= tooltipIcon("Das Kapitel ist nur für folgende Personen freigegeben: " . EportfolioFreigabe::userList($portfolio_id, $kapitel['id'])); ?>
                             <? endif ?>
                         <? else : ?>
                             Nicht freigegeben
-                            <?= tooltipIcon("Anschauen nicht möglich, da Nutzer dieses Kapitel nicht freigegeben hat") ?>
+                            <?= tooltipIcon("Das Anschauen ist nicht möglich, da der Nutzer dieses Kapitel noch nicht freigegeben hat") ?>
                         <? endif ?>
-
-
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Bisher gab es die zum Teil die Nachricht "Freigegeben aber kein Zugriff" mit dem Tooltip "Nutzer hat dieses Kapitel freigegeben, Sie sind jedoch eventuell nicht in der Supervisionsgruppe und können deshalb nicht darauf zugreifen".
Diese Nachricht ist insofern verwirrend, da der Dozent, der diese Nachricht sieht in der Supervisionsgruppe ist. Jedoch kommt diese Meldung, wenn das Kapitel für andere Personen, aber nicht für die Supervisionsgruppe freigegeben ist.
Entpsrechend des Vorschlages im Issue #323 habe ich zum Einen die direkt angezeigt Meldung, zum Anderen auch den Tooltip geändert, sodass im Tooltip jetzt eine Liste mit allen Zugriffsberechtigten auf das Kapitel erscheint.
Desweitern habe ich auch das dazugehörige FreigabeIcon geändert, sodass jetzt nur bei wirklichen Zugriffsrechten ein Accept-Icon und in allen anderen Fällen ein Decline-Icon angezeigt wird